### PR TITLE
現状の指示書更新とラベル自動テスト追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,155 +1,133 @@
 # GitHub Copilot Instructions for boothcsv
 
-## 日本語
-- 日本語で回答してください。
-- 今後のコメント類（PRタイトル/本文、レビューコメント、説明コメント、必要なコードコメント）は、ユーザーから別指定がない限り日本語で統一してください。
+## 言語ポリシー
+- 回答は日本語で行う。
+- PRタイトル・PR本文・レビューコメント・説明コメント・必要なコードコメントは、ユーザーから別指定がない限り日本語で統一する。
 
-## Project Overview
-This is a **client-side web application** for processing BOOTH (Japanese marketplace) shipping CSV files and generating printable labels/order details. It's built as a pure JavaScript application without external dependencies, running entirely in the browser with no server required.
+## プロジェクト概要
+- BOOTH の宛名印刷用 CSV を読み込み、注文票・ラベル・QR 関連情報をブラウザだけで扱うクライアントサイドアプリ。
+- 通常の Web / file:// 直開き / Chrome 拡張の 3 モードで動作する。
+- サーバー必須ではないが、ローカルサーバー起動用に `boothcsv.ps1` と `boothcsv.sh` がある。
+- 永続化は IndexedDB を使い、注文・設定・フォント・カスタムラベル・商品画像をローカル保存する。
 
-## Core Architecture
+## 現在の主要ファイル構成
 
-### File Structure & Responsibilities
-- **`boothcsv.html`** - Main HTML entry point with fixed header UI and sidebar
-- **`boothcsv.js`** (2700+ lines) - Main application logic, CSV processing, label generation
-- **`storage.js`** - IndexedDB wrapper (`UnifiedDatabase` class) for persistent storage (v9 schema)
-- **`order-repository.js`** - Order data management with in-memory cache and database sync
-- **`custom-labels.js`** - Custom label creation and editing functionality
-- **`custom-labels-font.js`** - Font management for custom labels
-- **External libs**: `papaparse.min.js` (CSV parsing), `jsQR.js` (QR code reading)
+### エントリポイントとUI
+- `boothcsv.html` - メイン画面。固定ヘッダー、サイドバー、処理済み注文一覧、各種テンプレートを持つ。
+- `help.html` - 使い方ガイド。
+- `css/boothcsv.css`, `css/sidebar.css` - メイン UI とサイドバーのスタイル。
 
-### Data Flow Pattern
-1. **CSV Upload** → `autoProcessCSV()` → Parse with PapaParse → Store in IndexedDB via `OrderRepository`
-2. **Label Generation** → `generateLabels()` → Create DOM elements with A4 44-label layout
-3. **Print Workflow** → Browser print → `updateSkipCount()` → Update cache & database for next session
+### アプリ本体
+- `js/boothcsv.js` - メイン制御。CSV 読み込み、印刷プレビュー生成、アプリモード判定、設定反映、バックアップ/リストア、Yamato 連携設定、各機能の配線を担当する。
+- `js/storage.js` - `UnifiedDatabase` と `StorageManager`。IndexedDB スキーマは現在 v11。
+- `js/order-repository.js` - 注文データのキャッシュと DB 同期を担う `OrderRepository`。
+- `js/processed-orders-panel.js` - 処理済み注文一覧の描画、ソート、フィルタ、複数選択、発送通知導線。
+- `js/custom-labels.js` - カスタムラベル編集 UI、保存、集計、複数面計算。
+- `js/custom-labels-font.js` - カスタムフォント管理。
+- `js/docs-capture.js` - ドキュメント用スクリーンショット撮影の補助。
 
-### Key Architectural Decisions
-- **No Server Required**: Everything runs client-side for privacy (sensitive shipping data)
-- **IndexedDB Storage**: Persistent storage with versioned schema (currently v9)
-- **Global State Management**: Uses `window.settingsCache` and `window.orderRepository` for cross-component state
-- **Label Layout**: Hardcoded for A4 44-label sheets (Japanese standard)
+### Chrome 拡張関連
+- `manifest.json` - MV3 マニフェスト。
+- `js/extension-bridge.js` - 拡張 UI から既存アプリへの橋渡し。
+- `js/extension-background.js` - BOOTH 画面との通信、CSV/QR/発送通知の自動化。
+- `js/booth-extension-content.js` - BOOTH 注文詳細ページで QR や発送状態を取得・操作する content script。
+- `docs/chrome-extension-dev-notes.md` - 拡張開発時の注意点と実装メモ。
 
-## Critical Patterns
+### 外部ライブラリ
+- `js/papaparse.min.js` - CSV 解析。
+- `js/jsQR.js` - QR 読み取り。
 
-### Settings Cache Synchronization
+## 実行モードと分岐方針
+- 実行モードは `extension` / `web` / `file` の 3 種類。
+- モード判定は `js/boothcsv.js` の `getForcedAppMode()` / `detectActualAppMode()` / `resolveAppMode()` / `getAppMode()` に集約されている。
+- UI の見た目差分は `document.body.dataset.appMode` を単一の真実源として扱い、できるだけ CSS と共通の表示更新処理で分岐する。
+- `?appMode=extension|web|file` による強制上書きは、デバッグやスクリーンショット撮影用として維持する。
+- 強制 `extension` モードは見た目確認用であり、Chrome 拡張 API が本当に使えることを意味しない。
+- 実際に拡張 API を呼べるかどうかは `canUseExtensionBridge()` や `isRealChromeExtensionApp()` で別途判定する。
+- `?extension=1` のような旧式の別パラメータは増やさず、`appMode` に統一する。
+
+## 主要データフロー
+1. CSV ファイル選択または拡張経由で CSV 取得。
+2. PapaParse でパースし、`OrderRepository.bulkUpsert()` で注文を IndexedDB とメモリキャッシュへ反映。
+3. `generateLabels()` などのプレビュー生成処理で注文票やラベルを DOM に描画。
+4. 印刷完了後は `updateSkipCount()` がラベルスキップ数を更新し、次回プレビューへ引き継ぐ。
+5. 処理済み注文一覧は `processed-orders-panel.js` が `OrderRepository` を参照して再プレビュー・削除・発送通知へつなぐ。
+
+## 永続化とストレージの重要事項
+- IndexedDB 名は `BoothCSVStorage`、スキーマバージョンは現在 v11。
+- 主なストアは `settings` / `fonts` / `orders` / `customLabels` / `productImages`。
+- バックアップ/リストアは `StorageManager.exportAllData()` / `StorageManager.importAllData()` を使い、上記ストアをまとめて JSON 化する。
+- カスタムラベルは設定 JSON ではなく独立ストアで扱う前提で考える。
+- 商品画像は `productImages` ストアで管理する。注文単位画像とは別の層なので混同しない。
+
+## このリポジトリで特に重要な実装パターン
+
+### 設定変更時の同期
+- 設定を変更するときは、`StorageManager.set(...)` だけで終わらせず `window.settingsCache` も必ず更新する。
+- 片方だけ更新すると、再プレビューや CSV 再読み込み後に不整合が起きやすい。
+
 ```javascript
-// Always update both storage AND cache when changing settings
 await StorageManager.set(StorageManager.KEYS.LABEL_SKIP, newValue);
-settingsCache.labelskip = newValue; // ⚠️ REQUIRED: Update cache too
+settingsCache.labelskip = newValue;
 ```
 
-### Order Repository Pattern
-```javascript
-// Repository manages both cache and database
-const repo = window.orderRepository;
-await repo.bulkUpsert(csvRows); // Updates cache + IndexedDB
-const order = repo.get(orderNumber); // Cache-first lookup
-```
+### 注文データアクセス
+- 注文データは `window.orderRepository` を経由して扱う。
+- 直接 IndexedDB を読みに行く前に、既存の repository API で足りるか確認する。
+- 注文番号は `OrderRepository.normalize()` 相当の正規化を前提に扱う。
 
-### Print Lifecycle
-```javascript
-// Print completion updates skip count for next session
-window.print() → user confirms → updateSkipCount() → recalculate label positions
-```
+### 処理済み注文一覧との整合
+- 注文の印刷済み・発送済み状態を変える変更は、処理済み注文一覧の UI と repository 更新通知まで含めて考える。
+- 単発プレビューだけ直して一覧を置き去りにしない。
 
-## Development Workflows
+### カスタムラベルの安全性
+- リッチテキストを扱うときは、既存の `sanitizeCustomLabelHTML()` / `sanitizeCustomLabelStyle()` の方針に合わせる。
+- カスタムラベルは内部モデルと差分保存を前提にしているので、DOM を直接いじるだけの実装を増やさない。
 
-### Local Development
-- Open `boothcsv.html` directly in Chrome (file:// protocol)
-- Add `?debug=1` to URL to enable debug logging
-- Use browser DevTools → Application → IndexedDB to inspect data
+### 画像・Blob URL
+- Blob URL を作る処理では、既存の `revokeBlobUrl()` / `revokeBlobImages()` の流れを崩さない。
+- 画像保存形式が `ArrayBuffer` か Blob URL かを確認し、既存の変換経路を再利用する。
 
-### App Mode / Environment Branching
-- This project currently has 3 meaningful runtime modes: `extension`, `web`, `file`
-- **Recommended rule**: do not scatter direct checks of `window.location.protocol`, `chrome.runtime`, or ad-hoc `hidden` toggles across unrelated features
-- Centralize environment resolution in one helper such as `getAppMode()` / `resolveAppMode()` and use that result everywhere
-- Prefer applying the resolved mode to the document root as a single source of truth, e.g. `document.body.dataset.appMode = 'extension|web|file'`
-- UI-only differences should be driven from that single app mode state, ideally by one updater function plus CSS selectors based on `body[data-app-mode="..."]`
-- Feature availability should be separated from UI mode. Example: "show extension-like UI for debugging" is different from "actual extension bridge is callable"
+## Chrome 拡張まわりの注意
+- 見た目が拡張モードでも、bridge が使えないケースを常に考慮する。
+- CSV 自動取得、QR 自動取得、発送通知は `extension-background.js`・`booth-extension-content.js`・`extension-bridge.js` の役割分担を崩さず実装する。
+- 発送通知はボタン押下だけで成功扱いにせず、最終的に発送日時などの状態確認まで取れてから保存する。
+- QR 取得は画像 URL 抽出、data URL 化、jsQR 解析、受付番号/パスワードのフォールバック保存まで含めて考える。
+- Chrome 拡張機能は「ゆるく」非公開の扱いとし、`README.md` や `help.html` などの公開寄りドキュメントでは積極的に案内しない。
+- ここでいう「ゆるく」非公開とは、ユーザーが自力で使う工夫まで積極的に妨げる意味ではないが、BOOTH 側サーバーに自動処理で関与する都合上、他者に強く勧めたり表立って宣伝したりしない、という運用方針を指す。
+- 厳密には BOOTH 側の規約違反になり得る前提で扱い、公開文書では通常機能のように紹介しない。必要なメモや実装知見は開発者向け文脈に閉じて記述する。
 
-### Forced Mode For Debugging
-- Keep a **forced app mode override** for debugging, especially when verifying UI with MCP chrome-devtools on localhost
-- Recommended override: query parameter such as `?appMode=extension`, `?appMode=web`, `?appMode=file`
-- This override is also important for taking screenshots used in help pages, usage guides, and documentation via MCP chrome-devtools
-- Precedence should be: explicit query override → actual runtime detection → fallback default
-- Forced `extension` mode is for **visual/UI debugging** and layout verification. It must not assume that Chrome extension APIs are really available
-- Real extension-only actions must still check capability separately, e.g. `canUseExtensionBridge()` or `isRealChromeExtensionApp()`
-- If a mode override is present, it should be easy to inspect in DevTools from `document.body.dataset.appMode`
-- Do not support a separate legacy override such as `?extension=1`; use `appMode=...` only
+## UI / CSS の作法
+- 新しいボタンは既存の共有クラスを優先して組み合わせる。
+- 基本は `btn-base` + サイズ系 + 色系で構成し、必要なら `btn-header` を重ねる。
+- 既存色 (`btn-primary`, `btn-success`, `btn-danger`, `btn-info`, `btn-warning`, `btn-download`, `btn-print-accent`) を先に使う。
+- app mode による見た目差分は、個別要素ごとの場当たり的な `hidden` 切り替えより、ルート状態と CSS セレクタを優先する。
 
-### Testing
-- Manual testing via `tests/phase6-tests.html` and `tests/custom-labels-store-test.html`
-- No automated test suite - relies on manual QA with sample CSV files in `sample/`
+## ドキュメント・スクリーンショット関連
+- `docs/images/` 配下の画像と `help.html` / `README.md` は連動している前提で扱う。
+- UI のスクリーンショット採取には `js/docs-capture.js` と `scripts/docs-capture/` の定義が使われる。
+- スクリーンショットやヘルプ更新時は、必要に応じて `?debug=1&appMode=...` を使い、再現可能な状態で撮る。
 
-### Debugging Tips
-- Enable debug mode: `?debug=1` in URL
-- For UI debugging, allow forced mode URLs such as `?debug=1&appMode=extension`
-- Use forced `extension` mode when checking extension-only layout in localhost via MCP chrome-devtools
-- Use the same forced mode URLs when taking screenshots for help content so the captured UI is reproducible later
-- Check `window.orderRepository.cache` for in-memory state
-- Inspect IndexedDB "BoothCSVStorage" v9 for persistent data
-- Look for console logs with category prefixes like `[csv]`, `[repo]`, `[image]`
+## ローカル開発と確認方法
+- 簡易確認は `boothcsv.html` を直接開いてもよいが、Web モード確認や docs-capture 利用時はローカルサーバー起動を優先する。
+- Windows は `.\boothcsv.ps1`、macOS / Linux は `./boothcsv.sh` を使える。
+- サンプルデータは `sample/` 配下を使う。
+- デバッグログは `?debug=1` で有効化され、`[csv]` / `[repo]` / `[image]` などのカテゴリを確認できる。
+- IndexedDB の確認はブラウザ DevTools の Application タブを使う。
 
-## Project-Specific Conventions
+## テスト方針
+- 現在、このリポジトリに自動テスト基盤はない前提で進める。
+- 変更時は、対象機能に応じて手動で確認手順を組み立てる。
+- とくに以下は壊しやすいので影響範囲に含める。
+  - CSV 読み込み
+  - ラベルスキップ数の反映
+  - 処理済み注文一覧の表示と操作
+  - カスタムラベル保存
+  - バックアップ/リストア
+  - 拡張モードの表示差分と bridge 可否
 
-### Environment Branching Conventions
-- Use **one** environment/app-mode resolver shared by the app, instead of duplicating `isChromeExtensionApp()` logic in multiple files
-- Use **one** UI visibility updater for mode-based show/hide rules, rather than per-feature ad-hoc DOM toggles where possible
-- Prefer CSS branching from root mode state for pure presentation differences
-- Prefer capability checks for behavior differences. Example:
-	- app mode decides whether extension-only controls are visible
-	- capability check decides whether clicking those controls is actually allowed
-- Avoid using URL parameters that are not consumed by the app. If extension launch passes a mode hint, it should map to the same unified app-mode mechanism
-- Prefer `appMode=...` as the only documented and supported debug/screenshot override
-- When adding new extension-only features, first decide whether the requirement is:
-	- visual difference only
-	- behavior difference only
-	- both visual and behavior difference
-	Then implement through the shared mode/capability system instead of introducing a new standalone branch
-
-### Button Styling Conventions
-- Prefer composing new buttons from existing shared classes instead of creating one-off button styles
-- Default composition should be `btn-base` + one size class + one color class
-- For header/main actions, prefer a reusable helper such as `btn-header` on top of `btn-base` rather than a brand new standalone button class
-- Reuse existing color variants first (`btn-primary`, `btn-success`, `btn-danger`, `btn-info`, `btn-warning`, `btn-download`, `btn-print-accent`) before introducing a new color token
-- New button-specific CSS should be limited to layout needs that cannot be expressed through the shared button classes
-- Avoid gradients, custom shadows, or duplicated hover/disabled rules unless a new visual language is intentionally required for the whole app
-
-### Error Handling
-- Non-blocking: Most errors are logged but don't halt execution
-- User feedback via `alert()` for critical errors
-- Storage operations have fallback mechanisms
-
-### Image Handling
-- Global images stored as ArrayBuffer in IndexedDB settings
-- Individual order images stored per order in repository
-- Uses Blob URLs for display to avoid memory leaks
-
-### Custom Label System
-- Independent storage with UNIX timestamp keys
-- Collision avoidance with monotonic counter
-- Rich text editing with font management
-
-## Integration Points
-
-### Browser APIs
-- **IndexedDB**: Primary storage (schema migrations handled automatically)
-- **File API**: CSV file reading and image handling
-- **Print API**: `window.print()` with CSS `@media print` rules
-- **Canvas API**: QR code processing with jsQR library
-
-### External Dependencies (CDN)
-- Paper.css for A4 print layouts
-- No build process - dependencies loaded via CDN or vendored
-
-## Key Gotchas
-- **Cache Consistency**: Always update both `settingsCache` and database when modifying settings
-- **Label Skip Logic**: Complex calculation involving 44-label sheets and print completion feedback
-- **QR Code Processing**: Expects specific format from BOOTH QR codes (3 parts separated by specific delimiters)
-- **Print CSS**: Layout relies heavily on CSS Grid and print media queries - test in print preview
-- **Mode vs capability**: "extension-looking UI" and "real Chrome extension APIs are callable" are not the same thing; keep them separate when implementing debug overrides
-
-## Common Tasks
-- **Add new setting**: Update `StorageManager.KEYS`, `settingsCache`, and UI binding in `registerSettingChangeHandlers()`
-- **Modify label layout**: Adjust `CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET` and related CSS
-- **Database changes**: Increment `UnifiedDatabase.version` and add migration logic in `createObjectStores()`
+## よくある変更の観点
+- 新しい設定を追加するなら、`StorageManager.KEYS`、デフォルト値、`settingsCache`、UI バインドを揃えて更新する。
+- DB スキーマ変更時は `UnifiedDatabase.version` を上げ、`createObjectStores()` と必要な移行処理を追加する。
+- 注文データの項目追加時は、repository キャッシュ・一覧 UI・バックアップ形式まで確認する。
+- 拡張機能の変更時は、実ページの DOM 依存と既存フォールバックの両方を確認する。

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,10 @@ logs/
 coverage/
 .nyc_output/
 
-tests/
+tests/*
+!tests/automated/
+tests/automated/*
+!tests/automated/label-sheet-layout.test.js
 backup/
 manifest.json
 docs/chrome-extension-dev-notes.md

--- a/boothcsv.html
+++ b/boothcsv.html
@@ -540,6 +540,7 @@
 <script src="./js/storage.js"></script>
 <!-- OrderRepository (orders 単一ソース化 Stage B) -->
 <script src="./js/order-repository.js"></script>
+<script src="./js/label-sheet-layout.js"></script>
 <!-- 分離されたカスタムラベル & フォント管理モジュール -->
 <script src="./js/custom-labels.js"></script>
 <script src="./js/custom-labels-font.js"></script>

--- a/js/boothcsv.js
+++ b/js/boothcsv.js
@@ -2221,69 +2221,49 @@ async function generateLabels(labelarr, options = {}) {
     skipOnFirstSheet: 0,
     ...options
   };
-  if (!Array.isArray(labelarr) || labelarr.length === 0) return; // 何も生成しない
-  // 全てが空スキップ要素("" など falsy)のみなら生成しない（全注文印刷済みで skip 指定だけのケースで空シートが出るのを防止）
-  const hasMeaningful = labelarr.some(l => {
-    if (!l) return false; // 空文字や null
-    if (typeof l === 'string') return l.trim() !== '';
-    // オブジェクト（カスタムラベルなど）は有効とみなす
-    return true;
-  });
-  if (!hasMeaningful) return;
-  // シートをちょうど埋めるために不足分だけ空ラベルを追加
-  if (labelarr.length % CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET) {
-    const remainder = labelarr.length % CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET;
-    const toFill = CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET - remainder;
-    for (let i = 0; i < toFill; i++) {
-      labelarr.push("");
-    }
-  }
-  
+  const layoutBuilder = window.BoothCSVLabelLayout && typeof window.BoothCSVLabelLayout.buildSheetLayouts === 'function'
+    ? window.BoothCSVLabelLayout.buildSheetLayouts
+    : null;
+  const sheetLayouts = layoutBuilder
+    ? layoutBuilder(labelarr, {
+        skipOnFirstSheet: opts.skipOnFirstSheet,
+        totalLabelsPerSheet: CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET
+      })
+    : [];
+  if (!Array.isArray(sheetLayouts) || sheetLayouts.length === 0) return;
+
   const tL44 = document.querySelector('#L44');
-  let cL44 = document.importNode(tL44.content, true);
-  // 生成するラベルシートに識別クラスを付与
-  cL44.querySelector('section.sheet')?.classList.add('label-sheet');
-  let tableL44 = cL44.querySelector("table");
-  let tr = document.createElement("tr");
-  let i = 0; // 全体インデックス
-  let sheetIndex = 0;
-  let posInSheet = 0; // 0..43
-  // C: 生成開始時にカウンタ初期化（既存を上書き）
   if (typeof window.currentLabelSheetCount !== 'number') window.currentLabelSheetCount = 0;
-  
-  for (let label of labelarr) {
-    if (i > 0 && i % CONSTANTS.LABEL.TOTAL_LABELS_PER_SHEET == 0) {
-      tableL44.appendChild(tr);
-      tr = document.createElement("tr");
-  document.body.insertBefore(cL44, tL44);
-  window.currentLabelSheetCount++;
-      cL44 = document.importNode(tL44.content, true);
-      cL44.querySelector('section.sheet')?.classList.add('label-sheet');
-      tableL44 = cL44.querySelector("table");
-      tr = document.createElement("tr");
-      sheetIndex++;
-      posInSheet = 0;
-    } else if (i > 0 && i % CONSTANTS.LABEL.LABELS_PER_ROW == 0) {
-      tableL44.appendChild(tr);
-      tr = document.createElement("tr");
+
+  for (const sheetLayout of sheetLayouts) {
+    const cL44 = document.importNode(tL44.content, true);
+    cL44.querySelector('section.sheet')?.classList.add('label-sheet');
+    const tableL44 = cL44.querySelector('table');
+    let tr = document.createElement('tr');
+
+    for (let i = 0; i < sheetLayout.items.length; i++) {
+      if (i > 0 && i % CONSTANTS.LABEL.LABELS_PER_ROW === 0) {
+        tableL44.appendChild(tr);
+        tr = document.createElement('tr');
+      }
+
+      const item = sheetLayout.items[i];
+      const td = await createLabel(item.label);
+      if (item.isSkipFace) {
+        td.classList.add('skip-face');
+        td.setAttribute('data-label-index', String(item.skipFaceNumber));
+        const indicator = document.createElement('div');
+        indicator.className = 'skip-indicator';
+        indicator.textContent = String(item.skipFaceNumber);
+        td.appendChild(indicator);
+      }
+      tr.appendChild(td);
     }
-    const td = await createLabel(label);
-    // スキップ面の視覚表示（初回シートの先頭skip数のみ）
-    if (sheetIndex === 0 && posInSheet < (opts.skipOnFirstSheet || 0)) {
-      td.classList.add('skip-face');
-      td.setAttribute('data-label-index', String(posInSheet + 1));
-      const indicator = document.createElement('div');
-      indicator.className = 'skip-indicator';
-      indicator.textContent = String(posInSheet + 1);
-      td.appendChild(indicator);
-    }
-    tr.appendChild(td);
-    posInSheet++;
-    i++;
+
+    tableL44.appendChild(tr);
+    document.body.insertBefore(cL44, tL44);
+    window.currentLabelSheetCount++;
   }
-  tableL44.appendChild(tr);
-  document.body.insertBefore(cL44, tL44);
-  window.currentLabelSheetCount++;
 }
 
 // div要素にpタグを追加するヘルパー関数

--- a/js/custom-labels.js
+++ b/js/custom-labels.js
@@ -3,6 +3,13 @@
 // CustomLabelCalculator もここに統合
 class CustomLabelCalculator {
   static calculateMultiSheetDistribution(totalLabels, skipCount){
+    if (window.BoothCSVLabelLayout && typeof window.BoothCSVLabelLayout.calculateMultiSheetDistribution === 'function') {
+      return window.BoothCSVLabelLayout.calculateMultiSheetDistribution(
+        totalLabels,
+        skipCount,
+        CONSTANTS?.LABEL?.TOTAL_LABELS_PER_SHEET || 44
+      );
+    }
     const sheetsInfo=[]; let remainingLabels=totalLabels; let currentSkip=skipCount; let sheetNumber=1;
     while(remainingLabels>0){
       const availableInSheet = (CONSTANTS?.LABEL?.TOTAL_LABELS_PER_SHEET||44) - currentSkip;

--- a/js/label-sheet-layout.js
+++ b/js/label-sheet-layout.js
@@ -1,0 +1,120 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  root.BoothCSVLabelLayout = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  'use strict';
+
+  function normalizeSheetSize(totalLabelsPerSheet) {
+    const parsed = parseInt(totalLabelsPerSheet, 10);
+    return parsed > 0 ? parsed : 44;
+  }
+
+  function normalizeSkipCount(skipCount, totalLabelsPerSheet) {
+    const parsed = parseInt(skipCount, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+    return Math.min(parsed, totalLabelsPerSheet - 1);
+  }
+
+  function hasMeaningfulLabel(label) {
+    if (!label) return false;
+    if (typeof label === 'string') return label.trim() !== '';
+    return true;
+  }
+
+  function padLabelsToFullSheets(labelarr, totalLabelsPerSheet) {
+    const padded = labelarr.slice();
+    const remainder = padded.length % totalLabelsPerSheet;
+    if (remainder === 0) return padded;
+    const toFill = totalLabelsPerSheet - remainder;
+    for (let i = 0; i < toFill; i++) {
+      padded.push('');
+    }
+    return padded;
+  }
+
+  function calculateMultiSheetDistribution(totalLabels, skipCount, totalLabelsPerSheet) {
+    const sheetSize = normalizeSheetSize(totalLabelsPerSheet);
+    const normalizedTotalLabels = Math.max(0, parseInt(totalLabels, 10) || 0);
+    let remainingLabels = normalizedTotalLabels;
+    let currentSkip = normalizeSkipCount(skipCount, sheetSize);
+    let sheetNumber = 1;
+    const sheetsInfo = [];
+
+    while (remainingLabels > 0) {
+      const availableInSheet = Math.max(0, sheetSize - currentSkip);
+      const labelsInThisSheet = Math.min(remainingLabels, availableInSheet);
+      const remainingInSheet = availableInSheet - labelsInThisSheet;
+
+      sheetsInfo.push({
+        sheetNumber,
+        skipCount: currentSkip,
+        labelCount: labelsInThisSheet,
+        remainingCount: remainingInSheet,
+        totalInSheet: currentSkip + labelsInThisSheet
+      });
+
+      remainingLabels -= labelsInThisSheet;
+      currentSkip = 0;
+      sheetNumber++;
+    }
+
+    if (sheetsInfo.length > 0) {
+      return sheetsInfo;
+    }
+
+    return [{
+      sheetNumber: 1,
+      skipCount: currentSkip,
+      labelCount: 0,
+      remainingCount: sheetSize - currentSkip,
+      totalInSheet: currentSkip
+    }];
+  }
+
+  function buildSheetLayouts(labelarr, options) {
+    const opts = options || {};
+    const totalLabelsPerSheet = normalizeSheetSize(opts.totalLabelsPerSheet);
+    const skipOnFirstSheet = normalizeSkipCount(opts.skipOnFirstSheet, totalLabelsPerSheet);
+
+    if (!Array.isArray(labelarr) || labelarr.length === 0) {
+      return [];
+    }
+
+    if (!labelarr.some(hasMeaningfulLabel)) {
+      return [];
+    }
+
+    const paddedLabels = padLabelsToFullSheets(labelarr, totalLabelsPerSheet);
+    const sheets = [];
+
+    paddedLabels.forEach(function(label, index) {
+      const sheetIndex = Math.floor(index / totalLabelsPerSheet);
+      const posInSheet = index % totalLabelsPerSheet;
+
+      if (!sheets[sheetIndex]) {
+        sheets[sheetIndex] = {
+          sheetIndex,
+          items: []
+        };
+      }
+
+      sheets[sheetIndex].items.push({
+        label,
+        sheetIndex,
+        posInSheet,
+        isSkipFace: sheetIndex === 0 && posInSheet < skipOnFirstSheet,
+        skipFaceNumber: sheetIndex === 0 && posInSheet < skipOnFirstSheet ? posInSheet + 1 : null
+      });
+    });
+
+    return sheets;
+  }
+
+  return {
+    calculateMultiSheetDistribution,
+    buildSheetLayouts
+  };
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "boothcsv",
+  "private": true,
+  "scripts": {
+    "test": "node --test .\\tests\\automated\\label-sheet-layout.test.js"
+  }
+}

--- a/tests/automated/label-sheet-layout.test.js
+++ b/tests/automated/label-sheet-layout.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildSheetLayouts,
+  calculateMultiSheetDistribution
+} = require('../../js/label-sheet-layout.js');
+
+test('最初のシートだけにスキップ面が付く', function() {
+  const labels = Array.from({ length: 50 }, function(_, index) {
+    return 'ORDER-' + String(index + 1);
+  });
+
+  const sheets = buildSheetLayouts(labels, {
+    skipOnFirstSheet: 3,
+    totalLabelsPerSheet: 44
+  });
+
+  assert.equal(sheets.length, 2);
+  assert.deepEqual(
+    sheets[0].items.filter(function(item) { return item.isSkipFace; }).map(function(item) { return item.skipFaceNumber; }),
+    [1, 2, 3]
+  );
+  assert.deepEqual(
+    sheets[1].items.filter(function(item) { return item.isSkipFace; }),
+    []
+  );
+});
+
+test('スキップ面数を含む複数シート分配は2ページ目でリセットされる', function() {
+  const sheets = calculateMultiSheetDistribution(50, 3, 44);
+
+  assert.deepEqual(sheets, [
+    { sheetNumber: 1, skipCount: 3, labelCount: 41, remainingCount: 0, totalInSheet: 44 },
+    { sheetNumber: 2, skipCount: 0, labelCount: 9, remainingCount: 35, totalInSheet: 9 }
+  ]);
+});
+
+test('1ページ目がほぼ埋まるケースでも2ページ目にはスキップ面が付かない', function() {
+  const sheets = calculateMultiSheetDistribution(2, 43, 44);
+
+  assert.deepEqual(sheets, [
+    { sheetNumber: 1, skipCount: 43, labelCount: 1, remainingCount: 0, totalInSheet: 44 },
+    { sheetNumber: 2, skipCount: 0, labelCount: 1, remainingCount: 43, totalInSheet: 1 }
+  ]);
+});
+
+test('意味のあるラベルがない場合はシートを生成しない', function() {
+  const sheets = buildSheetLayouts(['', '   ', null], {
+    skipOnFirstSheet: 5,
+    totalLabelsPerSheet: 44
+  });
+
+  assert.deepEqual(sheets, []);
+});


### PR DESCRIPTION
## 概要
- copilot-instructions を現状の構成と運用方針に合わせて日本語で更新
- ラベルのシート分割とスキップ面数ロジックを共有ユーティリティへ整理
- 2ページ目以降へスキップ面が波及しないことを自動テストで検証

## 変更内容
- copilot-instructions の全面更新
- label-sheet-layout.js の追加
- generateLabels と CustomLabelCalculator の共通ロジック化
- label-sheet-layout.test.js の追加
- package.json に npm test を追加
- .gitignore を調整

## 確認
- npm test