### PR TITLE
発行直後のQR返却にimageUrlを含める

### DIFF
--- a/js/booth-extension-content.js
+++ b/js/booth-extension-content.js
@@ -1055,26 +1055,32 @@
     return null;
   }
 
+  // canvas経路でdataUrl化に失敗しても、imageUrlがあればbackground側がfetchして救える。
+  // 3つの返却経路で同じ形にすること（imageUrlを落とすとデータ化失敗になる）。
+  function buildQrResponse(candidate, alreadyIssued) {
+    return {
+      ok: true,
+      dataUrl: candidate.dataUrl,
+      imageUrl: candidate.imageUrl || '',
+      diagnostics: candidate.diagnostics,
+      diagnosticsSummary: summarizeDiagnostics(candidate.diagnostics),
+      sourceType: candidate.type,
+      receiptnum: candidate.receiptnum || null,
+      receiptpassword: candidate.receiptpassword || null,
+      orderNumber: candidate.orderNumber || null,
+      expiresAt: candidate.expiresAt || null,
+      packageSizeLabel: candidate.packageSizeLabel || null,
+      alreadyIssued: !!alreadyIssued
+    };
+  }
+
   async function collectOrderQr(rawSettings) {
     // React描画完了前に判定すると、既発行QRを見落として発行フローへ誤って落ちる
     await waitForOrderDetailContent(12000);
 
     const existingQr = await getStructuredQrCandidate();
     if (existingQr) {
-      return {
-        ok: true,
-        dataUrl: existingQr.dataUrl,
-        imageUrl: existingQr.imageUrl,
-        diagnostics: existingQr.diagnostics,
-        diagnosticsSummary: summarizeDiagnostics(existingQr.diagnostics),
-        sourceType: existingQr.type,
-        receiptnum: existingQr.receiptnum,
-        receiptpassword: existingQr.receiptpassword,
-        orderNumber: existingQr.orderNumber,
-        expiresAt: existingQr.expiresAt,
-        packageSizeLabel: existingQr.packageSizeLabel,
-        alreadyIssued: true
-      };
+      return buildQrResponse(existingQr, true);
     }
 
     if (isShippedOrderPage()) {
@@ -1087,20 +1093,7 @@
     if (hasIssuedQrMetadata()) {
       const delayedExistingQr = await waitForExistingQr(8000);
       if (delayedExistingQr) {
-        return {
-          ok: true,
-          dataUrl: delayedExistingQr.dataUrl,
-          imageUrl: delayedExistingQr.imageUrl,
-          diagnostics: delayedExistingQr.diagnostics,
-          diagnosticsSummary: summarizeDiagnostics(delayedExistingQr.diagnostics),
-          sourceType: delayedExistingQr.type,
-          receiptnum: delayedExistingQr.receiptnum,
-          receiptpassword: delayedExistingQr.receiptpassword,
-          orderNumber: delayedExistingQr.orderNumber,
-          expiresAt: delayedExistingQr.expiresAt,
-          packageSizeLabel: delayedExistingQr.packageSizeLabel,
-          alreadyIssued: true
-        };
+        return buildQrResponse(delayedExistingQr, true);
       }
 
       const diagnostics = getCurrentQrDiagnostics();
@@ -1148,17 +1141,7 @@
       return { ok: false, error: 'QRコード画像またはcanvasを検出できませんでした' };
     }
 
-    return {
-      ok: true,
-      dataUrl: candidate.dataUrl,
-      sourceType: candidate.type,
-      receiptnum: candidate.receiptnum || null,
-      receiptpassword: candidate.receiptpassword || null,
-      orderNumber: candidate.orderNumber || null,
-      expiresAt: candidate.expiresAt || null,
-      packageSizeLabel: candidate.packageSizeLabel || null,
-      alreadyIssued: false
-    };
+    return buildQrResponse(candidate, false);
   }
 
   async function submitOrderShipmentNotification(messageTemplate) {


### PR DESCRIPTION
## 問題

拡張のQR取得で「QR画像のデータ化に失敗しました」（診断文字列なし）が発生していた。

原因は content script の**発行直後の返却経路だけ `imageUrl` を落としていた**こと。QR画像はCORSでcanvasが汚染されるため content script 側では data URL 化できず、background が `imageUrl` を fetch して data URL 化する経路が唯一の取得手段になる。`imageUrl` が無いと `normalizeQrResponse` が救済できず、`dataUrl` 無しのまま失敗する。

既発行パスには元から `imageUrl` があったため、発行直後パスだけが失敗していた。

## 修正

返却の形が経路ごとにズレていたのが原因なので、3つの返却経路（既発行・遅延検出・発行直後）を `buildQrResponse()` に集約した。今後どの経路も同じ形を返す。

-39/+22 で正味削減。

## 検証（実注文で実施）

- [x] 初回発行パス: `発送コードを発行する` ボタン検出 → 発行成功（PR #6 で未検証だった唯一の箇所）
- [x] アプリ側で設定した荷扱い（ワレモノ＋下積厳禁）・サイズ・品名が実際の発送コードに反映
- [x] 既発行パスでのQR取得成功
- [x] 未発行注文2件の一括取得（連続実行）で両方成功、取りこぼしなし
- [x] `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
